### PR TITLE
docs: add community ports section

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ All processing happens client-side using canvas. No AI, fully deterministic.
 
 The normalization core is plain JavaScript — React is just the wrapper. If you'd like to port Logo Soup to Vue, Svelte, Angular, or any other framework, go for it! We'd appreciate a link back to this repo, and let us know so we can link to your port from here.
 
+### Community Ports
+
+- **[Logo Soup](https://github.com/auroris/logo-soup)** — Vanilla HTML/JS implementation, no framework required
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a "Community Ports" subsection under "Porting to Other Frameworks" in the README
- Links to [auroris/logo-soup](https://github.com/auroris/logo-soup), a vanilla HTML/JS implementation with no framework dependency

## Test plan
- [ ] Verify the link renders correctly in the GitHub README
- [ ] Verify the link resolves to the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)