### PR TITLE
feat: expose __LOGO_SOUP__ detection global

### DIFF
--- a/.changeset/lucky-planes-hear.md
+++ b/.changeset/lucky-planes-hear.md
@@ -1,0 +1,5 @@
+---
+"@sanity-labs/logo-soup": minor
+---
+
+Expose a `globalThis.__LOGO_SOUP__` detection global (set to the package version) when an engine is created, so tools like Wappalyzer and HTTP Archive can identify sites using logo-soup

--- a/src/core/create-logo-soup.ts
+++ b/src/core/create-logo-soup.ts
@@ -34,6 +34,19 @@ const IDLE_STATE: LogoSoupState = {
   error: null,
 };
 
+declare const process: { env: { PKG_VERSION?: string } };
+
+// Detection fingerprint for tools like Wappalyzer, à la `__THREE__`/`__VUE__`
+function markGlobal() {
+  const g = globalThis as { __LOGO_SOUP__?: string };
+  try {
+    // PKG_VERSION is inlined at build time; catch covers browsers running raw source
+    g.__LOGO_SOUP__ ??= process.env.PKG_VERSION ?? "dev";
+  } catch {
+    g.__LOGO_SOUP__ ??= "dev";
+  }
+}
+
 function bgEqual(
   a: [number, number, number] | undefined,
   b: [number, number, number] | undefined,
@@ -44,6 +57,8 @@ function bgEqual(
 }
 
 export function createLogoSoup(): LogoSoupEngine {
+  markGlobal();
+
   const listeners = new Set<() => void>();
   const cache = new Map<string, CachedEntry>();
 

--- a/tests/createLogoSoup.test.ts
+++ b/tests/createLogoSoup.test.ts
@@ -61,6 +61,16 @@ describe("createLogoSoup", () => {
     engine.destroy();
   });
 
+  test("sets the __LOGO_SOUP__ detection global", () => {
+    const engine = createLogoSoup();
+
+    expect(
+      (globalThis as { __LOGO_SOUP__?: string }).__LOGO_SOUP__,
+    ).toBeString();
+
+    engine.destroy();
+  });
+
   test("getSnapshot returns stable reference when state has not changed", () => {
     const engine = createLogoSoup();
     const a = engine.getSnapshot();


### PR DESCRIPTION
There's currently no way to tell which websites use logo-soup. Creating an engine now sets `globalThis.__LOGO_SOUP__` to the package version, the same pattern as three.js `__THREE__` and Vue `__VUE__`: no DOM changes, no network, and it covers both component and headless hook usage since every adapter funnels through `createLogoSoup()`. The version is inlined at build time via pkg-utils' built-in `PKG_VERSION` define.

Once enough sites ship it we can submit a one-line detection rule to webappanalyzer, which feeds Wappalyzer and HTTP Archive's technologies table.