### PR TITLE
fix: stable snapshots for identical inputs and inline backgroundColor tuples

### DIFF
--- a/.changeset/stable-snapshots.md
+++ b/.changeset/stable-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@sanity-labs/logo-soup": patch
+---
+
+Fix a React render loop when `backgroundColor` is passed as an inline tuple (e.g. `backgroundColor={[255, 255, 255]}`). The engine now also keeps its snapshot referentially stable when `process()` is called with identical inputs on a warm cache, avoiding redundant emits across all framework adapters.

--- a/src/core/create-logo-soup.ts
+++ b/src/core/create-logo-soup.ts
@@ -71,6 +71,10 @@ export function createLogoSoup(): LogoSoupEngine {
   let prevDensityAware = false;
   let prevResolvedBg: [number, number, number] | undefined;
 
+  // Inputs behind the current "ready" snapshot; identical inputs on a warm
+  // cache skip emitting so getSnapshot() stays referentially stable
+  let readyKey: string | null = null;
+
   function emit() {
     for (const listener of listeners) {
       listener();
@@ -165,8 +169,22 @@ export function createLogoSoup(): LogoSoupEngine {
 
     const effectiveDensityFactor = densityAware ? densityFactor : 0;
 
+    const processKey = JSON.stringify([
+      sources.map((s) => [s.src, s.alt ?? ""]),
+      baseSize,
+      scaleFactor,
+      contrastThreshold,
+      densityAware,
+      effectiveDensityFactor,
+      cropToContent,
+      resolvedBg ?? null,
+    ]);
+
     // Fast path: everything is cached and no pending crops needed
     if (allCached && !needsCrop) {
+      if (snapshot.status === "ready" && processKey === readyKey) {
+        return;
+      }
       const results = sources.map((source) => {
         const entry = cache.get(source.src)!;
         const normalized = createNormalizedLogo(
@@ -181,6 +199,7 @@ export function createLogoSoup(): LogoSoupEngine {
         }
         return normalized;
       });
+      readyKey = processKey;
       setState({ status: "ready", normalizedLogos: results, error: null });
       return;
     }
@@ -256,10 +275,12 @@ export function createLogoSoup(): LogoSoupEngine {
       }
 
       if (results.length === 0 && firstError) {
+        readyKey = null;
         setState({ status: "error", normalizedLogos: [], error: firstError });
         return;
       }
 
+      readyKey = processKey;
       setState({ status: "ready", normalizedLogos: results, error: null });
     });
   }

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -1,4 +1,9 @@
-import type { LogoSource, MeasurementResult, NormalizedLogo } from "./types";
+import type {
+  BackgroundColor,
+  LogoSource,
+  MeasurementResult,
+  NormalizedLogo,
+} from "./types";
 
 export function logosEqual(
   a: (string | LogoSource)[],
@@ -14,6 +19,15 @@ export function logosEqual(
     if (srcA !== srcB) return false;
   }
   return true;
+}
+
+export function backgroundColorsEqual(
+  a: BackgroundColor | undefined,
+  b: BackgroundColor | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
 }
 
 export function normalizeSource(source: string | LogoSource): LogoSource {

--- a/src/react/use-logo-soup.ts
+++ b/src/react/use-logo-soup.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import { createLogoSoup } from "../core/create-logo-soup";
-import { logosEqual } from "../core/normalize";
+import { backgroundColorsEqual, logosEqual } from "../core/normalize";
 import type { LogoSoupState } from "../core/types";
 import type { UseLogoSoupOptions, UseLogoSoupResult } from "./types";
 
@@ -12,6 +12,18 @@ const SERVER_SNAPSHOT: LogoSoupState = {
 
 function getServerSnapshot(): LogoSoupState {
   return SERVER_SNAPSHOT;
+}
+
+/**
+ * Returns a referentially stable value across renders as long as `isEqual`
+ * holds, so inline literals (arrays, tuples) don't re-fire effects forever.
+ */
+function useStableValue<T>(value: T, isEqual: (a: T, b: T) => boolean): T {
+  const ref = useRef(value);
+  if (!isEqual(ref.current, value)) {
+    ref.current = value;
+  }
+  return ref.current;
 }
 
 export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupResult {
@@ -30,15 +42,11 @@ export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupResult {
 
   const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
-  // Stabilize the logos array reference to prevent infinite re-renders.
-  // Without this, a new array literal in the parent's render (e.g. logos={[a, b]})
-  // causes useEffect to re-fire, which calls process(), which emits a state change,
-  // which triggers useSyncExternalStore to re-render, which creates a new array, etc.
-  const logosRef = useRef(options.logos);
-  if (!logosEqual(logosRef.current, options.logos)) {
-    logosRef.current = options.logos;
-  }
-  const stableLogos = logosRef.current;
+  const stableLogos = useStableValue(options.logos, logosEqual);
+  const backgroundColor = useStableValue(
+    options.backgroundColor,
+    backgroundColorsEqual,
+  );
 
   const {
     baseSize,
@@ -47,7 +55,6 @@ export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupResult {
     densityAware,
     densityFactor,
     cropToContent,
-    backgroundColor,
   } = options;
 
   // Holds a deferred destroy timer so that StrictMode remounts can cancel it

--- a/tests/createLogoSoup.test.ts
+++ b/tests/createLogoSoup.test.ts
@@ -306,4 +306,45 @@ describe("createLogoSoup", () => {
 
     engine.destroy();
   });
+
+  test("re-processing identical inputs keeps the snapshot referentially stable", async () => {
+    installMockImage();
+    const engine = createLogoSoup();
+
+    const options = {
+      logos: ["a.png", "b.png"],
+      baseSize: 48,
+      scaleFactor: 0.5,
+      backgroundColor: [255, 255, 255] as [number, number, number],
+    };
+
+    engine.process(options);
+
+    await waitFor(() => {
+      expect(engine.getSnapshot().status).toBe("ready");
+    });
+
+    const ready = engine.getSnapshot();
+    let emitted = 0;
+    engine.subscribe(() => {
+      emitted++;
+    });
+
+    // Same inputs, new object/array references — must not emit or change state
+    engine.process({
+      ...options,
+      logos: ["a.png", "b.png"],
+      backgroundColor: [255, 255, 255],
+    });
+
+    expect(engine.getSnapshot()).toBe(ready);
+    expect(emitted).toBe(0);
+
+    // Changing a normalization param must still produce a new snapshot
+    engine.process({ ...options, baseSize: 96 });
+    expect(engine.getSnapshot()).not.toBe(ready);
+    expect(emitted).toBe(1);
+
+    engine.destroy();
+  });
 });

--- a/tests/useLogoSoup.test.tsx
+++ b/tests/useLogoSoup.test.tsx
@@ -228,6 +228,46 @@ describe("useLogoSoup", () => {
     globalThis.Image = originalImage;
   });
 
+  test("inline backgroundColor tuple does not cause a render loop", async () => {
+    globalThis.Image = class MockImage {
+      crossOrigin = "";
+      src = "";
+      naturalWidth = 200;
+      naturalHeight = 100;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      constructor() {
+        queueMicrotask(() => {
+          if (this.onload) this.onload();
+        });
+      }
+    } as unknown as typeof Image;
+
+    let renderCount = 0;
+
+    const { result } = renderHook(() => {
+      renderCount++;
+      // New array reference on every render — previously looped forever
+      return useLogoSoup({
+        logos: ["https://example.com/logo.png"],
+        backgroundColor: [255, 255, 255],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(true);
+    });
+
+    // Allow any pathological re-render cascade to reveal itself
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(renderCount).toBeLessThan(10);
+    expect(result.current.isReady).toBe(true);
+
+    globalThis.Image = originalImage;
+  });
+
   test("works correctly under React StrictMode (not stuck in loading)", async () => {
     globalThis.Image = class MockImage {
       crossOrigin = "";


### PR DESCRIPTION
Passing `backgroundColor` as an inline tuple (`backgroundColor={[255, 255, 255]}`) caused an infinite render loop in React.

- Stabilize `backgroundColor` in `useLogoSoup` with the same ref trick used for `logos`, extracted into a shared `useStableValue` helper
- The engine now skips emitting when `process()` runs with identical inputs on a warm cache, so `getSnapshot()` stays referentially stable for all adapters
- Both regression tests fail against the old code

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
