### PR TITLE
fix: reuse measurement CORS mode for rendered imgs to avoid double downloads

### DIFF
--- a/.changeset/rendered-img-cors.md
+++ b/.changeset/rendered-img-cors.md
@@ -1,0 +1,5 @@
+---
+"@sanity-labs/logo-soup": patch
+---
+
+Rendered `<img>` elements now set `crossOrigin="anonymous"` to match the measurement request. Browsers key the HTTP cache by request mode, so the mismatch caused every logo to be downloaded twice. Also adds `decoding="async"` and `role="list"`/`role="listitem"` semantics to the React component.

--- a/src/jquery/plugin.ts
+++ b/src/jquery/plugin.ts
@@ -46,6 +46,9 @@ function render(
     wrapper.style.transition = "opacity 0.2s ease-in-out";
 
     const img = document.createElement("img");
+    // Must match loadImage's CORS mode, or browsers re-download every logo
+    img.crossOrigin = "anonymous";
+    img.decoding = "async";
     img.src = logo.croppedSrc || logo.src;
     img.alt = logo.alt;
     img.width = logo.normalizedWidth;

--- a/src/react/logo-soup.tsx
+++ b/src/react/logo-soup.tsx
@@ -16,7 +16,8 @@ const logoImageStyle: CSSProperties = {
 };
 
 function DefaultImage(props: ImageRenderProps) {
-  return <img {...props} />;
+  // crossOrigin must match loadImage's, or browsers re-download every logo
+  return <img crossOrigin="anonymous" decoding="async" {...props} />;
 }
 
 export function LogoSoup({
@@ -54,8 +55,7 @@ export function LogoSoup({
     }
   }, [isReady, normalizedLogos, onNormalized]);
 
-  const halfGap =
-    typeof gap === "number" ? `${gap / 2}px` : `calc(${gap} / 2)`;
+  const halfGap = typeof gap === "number" ? `${gap / 2}px` : `calc(${gap} / 2)`;
 
   const containerStyle: CSSProperties = {
     textAlign: "center",
@@ -71,6 +71,7 @@ export function LogoSoup({
     <div
       className={className}
       style={containerStyle}
+      role="list"
       data-logo-soup-loading={isLoading}
     >
       {normalizedLogos.map((logo, index) => {
@@ -79,6 +80,7 @@ export function LogoSoup({
         return (
           <span
             key={`${logo.src}-${index}`}
+            role="listitem"
             style={{
               ...logoWrapperStyle,
               padding: halfGap,

--- a/tests/logoSoup.test.tsx
+++ b/tests/logoSoup.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { render, waitFor } from "@testing-library/react";
+import { LogoSoup } from "../src/react/logo-soup";
+
+const originalImage = globalThis.Image;
+
+function installMockImage() {
+  globalThis.Image = class MockImage {
+    crossOrigin = "";
+    src = "";
+    naturalWidth = 200;
+    naturalHeight = 100;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+
+    constructor() {
+      queueMicrotask(() => {
+        this.onload?.();
+      });
+    }
+  } as unknown as typeof Image;
+}
+
+describe("LogoSoup", () => {
+  test("rendered imgs reuse the measurement CORS mode and expose list semantics", async () => {
+    installMockImage();
+
+    const { container } = render(
+      <LogoSoup logos={[{ src: "https://example.com/a.png", alt: "A" }]} />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("img")).not.toBeNull();
+    });
+
+    const img = container.querySelector("img")!;
+    // Must match loadImage's crossOrigin, or browsers re-download every logo
+    expect(img.getAttribute("crossorigin")).toBe("anonymous");
+    expect(img.getAttribute("alt")).toBe("A");
+
+    expect(container.querySelector("[role='list']")).not.toBeNull();
+    expect(container.querySelector("[role='listitem']")).not.toBeNull();
+
+    globalThis.Image = originalImage;
+  });
+});


### PR DESCRIPTION
Measurement loads images with `crossOrigin: "anonymous"` but the rendered `<img>` tags didn't set it, so browsers downloaded every logo twice (the HTTP cache is keyed by request mode).

- Set `crossOrigin="anonymous"` and `decoding="async"` on rendered imgs in the React and jQuery renderers
- Add `role="list"` / `role="listitem"` semantics to the React component
- New component test covers the rendered attributes

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
