### PR TITLE
feat: perceptual redmean color distance and high-quality measurement downscale

### DIFF
--- a/.changeset/measure-accuracy.md
+++ b/.changeset/measure-accuracy.md
@@ -1,0 +1,5 @@
+---
+"@sanity-labs/logo-soup": patch
+---
+
+Measurement accuracy improvements: content classification and visual-center weighting now use the perceptually-weighted "redmean" color distance instead of plain RGB Euclidean (thresholds rescaled so `contrastThreshold` semantics are unchanged for neutral contrast), and the measurement downscale uses `imageSmoothingQuality: "high"` so hairline strokes survive the downsample. Measured values (contentBox, visualCenter, pixelDensity) may shift slightly.

--- a/docs/how-it-works.mdx
+++ b/docs/how-it-works.mdx
@@ -18,7 +18,7 @@ Most logos have invisible padding, transparent borders, or solid-color backgroun
 ### Transparent vs opaque backgrounds
 
 - **Transparent logos** (PNGs/SVGs with alpha): pixels with alpha below the `contrastThreshold` are ignored. Content is everything with meaningful opacity.
-- **Opaque logos** (JPEGs, logos on solid backgrounds): the engine samples the image perimeter using a color histogram (quantized to 8-level buckets) to find the dominant background color. Pixels within `contrastThreshold` RGB distance of this color are treated as background.
+- **Opaque logos** (JPEGs, logos on solid backgrounds): the engine samples the image perimeter using a color histogram (quantized to 8-level buckets) to find the dominant background color. Pixels within `contrastThreshold` distance of this color are treated as background, using the perceptually-weighted ["redmean" color distance](https://en.wikipedia.org/wiki/Color_difference) rather than plain RGB Euclidean — green differences count more, blue less, matching human contrast perception.
 
 You can override the auto-detection by providing `backgroundColor` explicitly, which is recommended for opaque logos on known backgrounds.
 
@@ -38,11 +38,11 @@ normalizedWidth = aspectRatio ^ scaleFactor × baseSize
 
 The `scaleFactor` parameter controls the balance between width uniformity and height uniformity:
 
-| `scaleFactor` | Effect | Math |
-| --- | --- | --- |
-| `0` | All logos get the same width (`baseSize`) | `ratio^0 = 1`, so `width = baseSize` for all |
-| `1` | All logos get the same height (`baseSize`) | `ratio^1 × baseSize / ratio = baseSize` for all |
-| `0.5` | Balanced — neither too wide nor too tall | Square root dampens extreme ratios |
+| `scaleFactor` | Effect                                     | Math                                            |
+| ------------- | ------------------------------------------ | ----------------------------------------------- |
+| `0`           | All logos get the same width (`baseSize`)  | `ratio^0 = 1`, so `width = baseSize` for all    |
+| `1`           | All logos get the same height (`baseSize`) | `ratio^1 × baseSize / ratio = baseSize` for all |
+| `0.5`         | Balanced — neither too wide nor too tall   | Square root dampens extreme ratios              |
 
 The default `0.5` works well for most logo sets. It's the geometric mean between uniform-width and uniform-height, producing visually balanced results regardless of whether your set has more wide or tall logos.
 
@@ -63,6 +63,7 @@ pixelDensity = coverageRatio × averageOpacity
 ```
 
 Where:
+
 - `coverageRatio` = fraction of pixels within the content box that are classified as content
 - `averageOpacity` = average opacity of those content pixels (normalized 0–1)
 
@@ -104,10 +105,11 @@ Where `darkness = 1 - backgroundLuminance` and `density` is the logo's pixel den
 This is a subtle effect (typically 1–4% reduction), but it measurably improves visual balance in dark mode. It only applies to opaque images where the background luminance can be determined — transparent logos are unaffected.
 
 <Info>
-  References:
-  - [Helmholtz irradiation illusion (1860s)](https://en.wikipedia.org/wiki/Irradiation_illusion)
-  - [Jano Garcia's research compilation](https://gist.github.com/janogarcia/e9f57cd18ca85756743f81d9692764b7)
-  - [Adam Argyle: Adjust perceived typeface weight for dark mode](https://nerdy.dev/adjust-perceived-typepace-weight-for-dark-mode-without-layout-shift)
+  References: - [Helmholtz irradiation illusion
+  (1860s)](https://en.wikipedia.org/wiki/Irradiation_illusion) - [Jano Garcia's research
+  compilation](https://gist.github.com/janogarcia/e9f57cd18ca85756743f81d9692764b7) - [Adam Argyle:
+  Adjust perceived typeface weight for dark
+  mode](https://nerdy.dev/adjust-perceived-typepace-weight-for-dark-mode-without-layout-shift)
 </Info>
 
 ## 5. Visual Center Alignment

--- a/docs/performance.mdx
+++ b/docs/performance.mdx
@@ -25,8 +25,12 @@ for (let i = 0; i < pixelCount; i++) {
   const g = (pixel >>> 8) & 0xff;
   const b = (pixel >>> 16) & 0xff;
 
-  // squared euclidean distance from background
-  const distSq = (r - bgR) ** 2 + (g - bgG) ** 2 + (b - bgB) ** 2;
+  // perceptually-weighted ("redmean") distance from background
+  const rMean = (r + bgR) >> 1;
+  const distSq =
+    (2 + rMean / 256) * (r - bgR) ** 2 +
+    4 * (g - bgG) ** 2 +
+    (2 + (255 - rMean) / 256) * (b - bgB) ** 2;
   if (distSq < contrastDistanceSq) continue;
 
   // recover x,y from flat index
@@ -62,12 +66,12 @@ If `process()` is called while a previous run is still loading images, the in-fl
 
 Every pull request automatically runs a benchmark suite against real SVG logos from the test set. Here are typical numbers from CI:
 
-| Benchmark | Time |
-|:----------|-----:|
-| Content detection (1 logo) | ~36us |
-| Render pass (20 logos) | ~1us |
+| Benchmark                           |   Time |
+| :---------------------------------- | -----: |
+| Content detection (1 logo)          |  ~36us |
+| Render pass (20 logos)              |   ~1us |
 | Full mount, no detection (20 logos) | ~3.5us |
-| Full mount, defaults (20 logos) | ~880us |
+| Full mount, defaults (20 logos)     | ~880us |
 
 Detection dominates the cost. Once measurements are cached, subsequent layout updates (changing `baseSize`, `scaleFactor`, or `alignBy`) are effectively free -- nearly 400x faster than a full mount.
 
@@ -75,12 +79,12 @@ Detection dominates the cost. Once measurements are cached, subsequent layout up
 
 The CI suite also measures how expensive individual features are relative to having them off:
 
-| Feature | On | Off | Cost |
-|:--------|---:|----:|:-----|
-| `densityAware` | ~35us | ~34us | Negligible (same pass) |
-| `alignBy: "visual-center-y"` vs `"bounds"` | ~1us | ~59ns | 18x (but both are sub-microsecond) |
-| `cropToContent` | ~2ms | ~0ns | 2ms (canvas crop + blob URL) |
-| Layout update: full mount vs cached | ~880us | ~2us | 400x (pixel scan vs pure math) |
+| Feature                                    |     On |   Off | Cost                               |
+| :----------------------------------------- | -----: | ----: | :--------------------------------- |
+| `densityAware`                             |  ~35us | ~34us | Negligible (same pass)             |
+| `alignBy: "visual-center-y"` vs `"bounds"` |   ~1us | ~59ns | 18x (but both are sub-microsecond) |
+| `cropToContent`                            |   ~2ms |  ~0ns | 2ms (canvas crop + blob URL)       |
+| Layout update: full mount vs cached        | ~880us |  ~2us | 400x (pixel scan vs pure math)     |
 
 ## CI regression detection
 
@@ -93,7 +97,8 @@ The benchmark suite uses [Welch's t-test](https://en.wikipedia.org/wiki/Welch%27
 This avoids false positives from measurement noise while catching real regressions. The comparison table and feature cost breakdown are posted directly on the PR as a comment, along with a link to the full CI job logs.
 
 <Tip>
-  You can run benchmarks locally with `bun run bench`. The suite uses `@napi-rs/canvas` and `@happy-dom/global-registrator` to run the same pixel scanning code outside a browser.
+  You can run benchmarks locally with `bun run bench`. The suite uses `@napi-rs/canvas` and
+  `@happy-dom/global-registrator` to run the same pixel scanning code outside a browser.
 </Tip>
 
 ## Tips for your application
@@ -106,10 +111,10 @@ When Logo Soup doesn't know the background color, it samples the image perimeter
 
 Each feature has a measurable cost. If you don't need density compensation, visual center alignment, or content cropping, turning them off saves work:
 
-| Feature | Effect when disabled |
-|:--------|:---------------------|
-| `densityAware: false` | Skips density computation during pixel scan |
-| `alignBy: "bounds"` | Skips visual center transform calculation |
+| Feature                | Effect when disabled                                      |
+| :--------------------- | :-------------------------------------------------------- |
+| `densityAware: false`  | Skips density computation during pixel scan               |
+| `alignBy: "bounds"`    | Skips visual center transform calculation                 |
 | `cropToContent: false` | Skips canvas crop and blob URL creation (saves ~2ms/logo) |
 
 ### Cache-friendly option changes

--- a/src/core/measure-pixels.ts
+++ b/src/core/measure-pixels.ts
@@ -182,7 +182,9 @@ export function scanPixels(options: ContentScanOptions): MeasurementResult {
   const scaleX = w / sw;
   const scaleY = h / sh;
 
-  const contrastDistanceSq = contrastThreshold * contrastThreshold * 3;
+  // ×9 not ×3: redmean weights sum to ~9 for neutral deltas, keeping
+  // contrastThreshold semantics unchanged
+  const contrastDistanceSq = contrastThreshold * contrastThreshold * 9;
 
   let bgR: number;
   let bgG: number;
@@ -243,11 +245,17 @@ export function scanPixels(options: ContentScanOptions): MeasurementResult {
       const dg = g - bgG;
       const db = b - bgB;
 
-      const distSq = dr * dr + dg * dg + db * db;
+      // Redmean perceptual distance: https://en.wikipedia.org/wiki/Color_difference
+      const rMean = (r + bgR) >> 1;
+      const distSq =
+        (2 + rMean / 256) * dr * dr +
+        4 * dg * dg +
+        (2 + (255 - rMean) / 256) * db * db;
       if (distSq < contrastDistanceSq) continue;
 
       weight = distSq * a;
-      opacity = Math.min(a, Math.sqrt(distSq));
+      // /3 normalizes redmean back to the plain-RGB opacity scale
+      opacity = Math.min(a, Math.sqrt(distSq / 3));
     }
 
     const x = i % sw;

--- a/src/core/measure.ts
+++ b/src/core/measure.ts
@@ -18,6 +18,9 @@ function createReusableCanvas(
     if (prevW !== w || prevH !== h) {
       canvas.width = w;
       canvas.height = h;
+      // Re-set after resize (resizing resets context state); high quality
+      // keeps hairline strokes through the downscale
+      ctx.imageSmoothingQuality = "high";
       prevW = w;
       prevH = h;
     } else {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -44,7 +44,11 @@ export async function measureImage(
 
   return (
     measureContent(
-      (sw, sh) => createCanvas(sw, sh).getContext("2d"),
+      (sw, sh) => {
+        const ctx = createCanvas(sw, sh).getContext("2d");
+        ctx.imageSmoothingQuality = "high";
+        return ctx;
+      },
       img,
       w,
       h,

--- a/tests/node.test.ts
+++ b/tests/node.test.ts
@@ -121,6 +121,7 @@ describe("parity with scanPixels", () => {
       const { sw, sh } = downsampleDimensions(img.width, img.height);
       const canvas = createCanvas(sw, sh);
       const ctx = canvas.getContext("2d");
+      ctx.imageSmoothingQuality = "high";
       ctx.drawImage(img, 0, 0, sw, sh);
       const imageData = ctx.getImageData(0, 0, sw, sh);
       const data32 = new Uint32Array(imageData.data.buffer);


### PR DESCRIPTION
Two accuracy improvements to the pixel scan:

- Content classification and visual-center weighting now use the perceptually weighted [redmean color distance](https://en.wikipedia.org/wiki/Color_difference) instead of plain RGB Euclidean. Thresholds are rescaled so `contrastThreshold` semantics are unchanged for neutral contrast
- The measurement downscale uses `imageSmoothingQuality: "high"` so hairline strokes survive the aggressive downsample

Measured values (contentBox, visualCenter, pixelDensity) shift slightly. Golden snapshots that lock the new values in land in the next PR of the stack. Bench cost is negligible (~43µs detection, was ~37µs).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
