### PR TITLE
feat: report per-logo load failures across all adapters

### DIFF
--- a/.changeset/partial-failures.md
+++ b/.changeset/partial-failures.md
@@ -1,0 +1,5 @@
+---
+"@sanity-labs/logo-soup": minor
+---
+
+Report per-logo failures. Previously a logo that failed to load silently disappeared from the results with no way to detect which one broke. The engine state now includes `failures: { src, error }[]`, exposed through every adapter (`useLogoSoup().failures`, Vue/Solid/Svelte getters), and the React `<LogoSoup>` component accepts an `onError(failures)` callback. `status` and `error` semantics are unchanged.

--- a/src/angular/logo-soup.service.ts
+++ b/src/angular/logo-soup.service.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  signal,
-  inject,
-  DestroyRef,
-} from "@angular/core";
+import { Injectable, signal, inject, DestroyRef } from "@angular/core";
 import { createLogoSoup as createEngine } from "../core/create-logo-soup";
 import type { ProcessOptions, LogoSoupState } from "../core/types";
 
@@ -11,6 +6,7 @@ const IDLE_STATE: LogoSoupState = {
   status: "idle",
   normalizedLogos: [],
   error: null,
+  failures: [],
 };
 
 @Injectable()

--- a/src/core/create-logo-soup.ts
+++ b/src/core/create-logo-soup.ts
@@ -14,6 +14,7 @@ import {
 } from "./measure";
 import { createNormalizedLogo, normalizeSource } from "./normalize";
 import type {
+  LogoFailure,
   LogoSoupEngine,
   LogoSoupState,
   LogoSource,
@@ -28,10 +29,13 @@ interface CachedEntry {
   blobUrl?: string;
 }
 
+const NO_FAILURES: LogoFailure[] = [];
+
 const IDLE_STATE: LogoSoupState = {
   status: "idle",
   normalizedLogos: [],
   error: null,
+  failures: NO_FAILURES,
 };
 
 declare const process: { env: { PKG_VERSION?: string } };
@@ -86,7 +90,8 @@ export function createLogoSoup(): LogoSoupEngine {
     if (
       snapshot.status === next.status &&
       snapshot.normalizedLogos === next.normalizedLogos &&
-      snapshot.error === next.error
+      snapshot.error === next.error &&
+      snapshot.failures === next.failures
     ) {
       return;
     }
@@ -135,7 +140,12 @@ export function createLogoSoup(): LogoSoupEngine {
 
     // Empty logos — go straight to ready with empty results
     if (logos.length === 0) {
-      setState({ status: "ready", normalizedLogos: [], error: null });
+      setState({
+        status: "ready",
+        normalizedLogos: [],
+        error: null,
+        failures: NO_FAILURES,
+      });
       return;
     }
 
@@ -200,7 +210,12 @@ export function createLogoSoup(): LogoSoupEngine {
         return normalized;
       });
       readyKey = processKey;
-      setState({ status: "ready", normalizedLogos: results, error: null });
+      setState({
+        status: "ready",
+        normalizedLogos: results,
+        error: null,
+        failures: NO_FAILURES,
+      });
       return;
     }
 
@@ -211,7 +226,12 @@ export function createLogoSoup(): LogoSoupEngine {
     };
 
     if (!allCached) {
-      setState({ status: "loading", normalizedLogos: [], error: null });
+      setState({
+        status: "loading",
+        normalizedLogos: [],
+        error: null,
+        failures: NO_FAILURES,
+      });
     }
 
     Promise.allSettled(
@@ -262,26 +282,40 @@ export function createLogoSoup(): LogoSoupEngine {
       if (cancelled || destroyed) return;
 
       const results: NormalizedLogo[] = [];
-      let firstError: Error | undefined;
-      for (const r of settled) {
+      const failures: LogoFailure[] = [];
+      for (let i = 0; i < settled.length; i++) {
+        const r = settled[i]!;
         if (r.status === "fulfilled") {
           results.push(r.value);
-        } else if (!firstError) {
-          firstError =
-            r.reason instanceof Error
-              ? r.reason
-              : new Error("Failed to load logo");
+        } else {
+          failures.push({
+            src: sources[i]!.src,
+            error:
+              r.reason instanceof Error
+                ? r.reason
+                : new Error("Failed to load logo"),
+          });
         }
       }
 
-      if (results.length === 0 && firstError) {
+      if (results.length === 0 && failures.length > 0) {
         readyKey = null;
-        setState({ status: "error", normalizedLogos: [], error: firstError });
+        setState({
+          status: "error",
+          normalizedLogos: [],
+          error: failures[0]!.error,
+          failures,
+        });
         return;
       }
 
       readyKey = processKey;
-      setState({ status: "ready", normalizedLogos: results, error: null });
+      setState({
+        status: "ready",
+        normalizedLogos: results,
+        error: null,
+        failures: failures.length > 0 ? failures : NO_FAILURES,
+      });
     });
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -19,6 +19,7 @@ export type {
   AlignmentMode,
   BackgroundColor,
   BoundingBox,
+  LogoFailure,
   LogoSoupEngine,
   LogoSoupState,
   LogoSource,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -65,11 +65,19 @@ export type ProcessOptions = {
   backgroundColor?: BackgroundColor;
 };
 
+/** A logo that failed to load or measure during a processing run */
+export type LogoFailure = {
+  src: string;
+  error: Error;
+};
+
 /** Immutable state snapshot returned by the engine */
 export type LogoSoupState = {
   status: "idle" | "loading" | "ready" | "error";
   normalizedLogos: NormalizedLogo[];
   error: Error | null;
+  /** Per-logo failures from the last run; `error` is only set when all fail */
+  failures: LogoFailure[];
 };
 
 /** The imperative engine returned by `createLogoSoup()` */

--- a/src/react/logo-soup.tsx
+++ b/src/react/logo-soup.tsx
@@ -35,8 +35,9 @@ export function LogoSoup({
   className,
   style,
   onNormalized,
+  onError,
 }: LogoSoupProps) {
-  const { isLoading, isReady, normalizedLogos, error } = useLogoSoup({
+  const { isLoading, isReady, normalizedLogos, error, failures } = useLogoSoup({
     logos,
     baseSize,
     scaleFactor,
@@ -54,6 +55,12 @@ export function LogoSoup({
       onNormalized(normalizedLogos);
     }
   }, [isReady, normalizedLogos, onNormalized]);
+
+  useEffect(() => {
+    if (failures.length > 0 && onError) {
+      onError(failures);
+    }
+  }, [failures, onError]);
 
   const halfGap = typeof gap === "number" ? `${gap / 2}px` : `calc(${gap} / 2)`;
 

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -2,6 +2,7 @@ import type { CSSProperties, ImgHTMLAttributes, ReactNode } from "react";
 import type {
   AlignmentMode,
   BackgroundColor,
+  LogoFailure,
   LogoSource,
   NormalizedLogo,
 } from "../core/types";
@@ -32,6 +33,8 @@ export type UseLogoSoupResult = {
   isReady: boolean;
   normalizedLogos: NormalizedLogo[];
   error: Error | null;
+  /** Logos that failed to load in the last run (absent from normalizedLogos) */
+  failures: LogoFailure[];
 };
 
 export type LogoSoupProps = {
@@ -49,4 +52,6 @@ export type LogoSoupProps = {
   className?: string;
   style?: CSSProperties;
   onNormalized?: (logos: NormalizedLogo[]) => void;
+  /** Called when one or more logos fail to load (including total failure) */
+  onError?: (failures: LogoFailure[]) => void;
 };

--- a/src/react/use-logo-soup.ts
+++ b/src/react/use-logo-soup.ts
@@ -8,6 +8,7 @@ const SERVER_SNAPSHOT: LogoSoupState = {
   status: "idle",
   normalizedLogos: [],
   error: null,
+  failures: [],
 };
 
 function getServerSnapshot(): LogoSoupState {
@@ -101,5 +102,6 @@ export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupResult {
     isReady: state.status === "ready",
     normalizedLogos: state.normalizedLogos,
     error: state.error,
+    failures: state.failures,
   };
 }

--- a/src/solid/use-logo-soup.ts
+++ b/src/solid/use-logo-soup.ts
@@ -1,6 +1,7 @@
 import { from, createEffect, onCleanup } from "solid-js";
 import { createLogoSoup as createEngine } from "../core/create-logo-soup";
 import type {
+  LogoFailure,
   LogoSoupState,
   NormalizedLogo,
   ProcessOptions,
@@ -10,6 +11,7 @@ const IDLE_STATE: LogoSoupState = {
   status: "idle",
   normalizedLogos: [],
   error: null,
+  failures: [],
 };
 
 export type UseLogoSoupResult = {
@@ -17,9 +19,12 @@ export type UseLogoSoupResult = {
   readonly isReady: boolean;
   readonly normalizedLogos: NormalizedLogo[];
   readonly error: Error | null;
+  readonly failures: LogoFailure[];
 };
 
-export function useLogoSoup(optionsFn: () => ProcessOptions): UseLogoSoupResult {
+export function useLogoSoup(
+  optionsFn: () => ProcessOptions,
+): UseLogoSoupResult {
   const engine = createEngine();
 
   // from() accepts a producer function: (setter) => unsubscribe
@@ -49,6 +54,9 @@ export function useLogoSoup(optionsFn: () => ProcessOptions): UseLogoSoupResult 
     },
     get error() {
       return (state() ?? IDLE_STATE).error;
+    },
+    get failures() {
+      return (state() ?? IDLE_STATE).failures;
     },
   };
 }

--- a/src/svelte/create-logo-soup.svelte.ts
+++ b/src/svelte/create-logo-soup.svelte.ts
@@ -42,6 +42,11 @@ export function createLogoSoup() {
       return engine.getSnapshot().error;
     },
 
+    get failures() {
+      subscribe();
+      return engine.getSnapshot().failures;
+    },
+
     destroy() {
       engine.destroy();
     },

--- a/src/vue/use-logo-soup.ts
+++ b/src/vue/use-logo-soup.ts
@@ -11,6 +11,7 @@ import {
 import { createLogoSoup } from "../core/create-logo-soup";
 import type {
   BackgroundColor,
+  LogoFailure,
   LogoSource,
   LogoSoupState,
   NormalizedLogo,
@@ -34,6 +35,7 @@ export type UseLogoSoupReturn = {
   isReady: ComputedRef<boolean>;
   normalizedLogos: ComputedRef<NormalizedLogo[]>;
   error: ComputedRef<Error | null>;
+  failures: ComputedRef<LogoFailure[]>;
 };
 
 export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupReturn {
@@ -68,6 +70,7 @@ export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupReturn {
   const isReady = computed(() => state.value.status === "ready");
   const normalizedLogos = computed(() => state.value.normalizedLogos);
   const error = computed(() => state.value.error);
+  const failures = computed(() => state.value.failures);
 
-  return { state, isLoading, isReady, normalizedLogos, error };
+  return { state, isLoading, isReady, normalizedLogos, error, failures };
 }

--- a/tests/createLogoSoup.test.ts
+++ b/tests/createLogoSoup.test.ts
@@ -307,6 +307,58 @@ describe("createLogoSoup", () => {
     engine.destroy();
   });
 
+  test("partial failure: reports failures but stays ready with the successes", async () => {
+    globalThis.Image = class MockImage {
+      crossOrigin = "";
+      src = "";
+      naturalWidth = 200;
+      naturalHeight = 100;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      constructor() {
+        queueMicrotask(() => {
+          if (this.src.includes("broken")) this.onerror?.();
+          else this.onload?.();
+        });
+      }
+    } as unknown as typeof Image;
+
+    const engine = createLogoSoup();
+    engine.process({ logos: ["ok.png", "broken.png"] });
+
+    await waitFor(() => {
+      expect(engine.getSnapshot().status).toBe("ready");
+    });
+
+    const snapshot = engine.getSnapshot();
+    expect(snapshot.normalizedLogos).toHaveLength(1);
+    expect(snapshot.normalizedLogos[0]?.src).toBe("ok.png");
+    expect(snapshot.error).toBe(null);
+    expect(snapshot.failures).toHaveLength(1);
+    expect(snapshot.failures[0]?.src).toBe("broken.png");
+    expect(snapshot.failures[0]?.error).toBeInstanceOf(Error);
+
+    engine.destroy();
+  });
+
+  test("total failure: failures lists every logo", async () => {
+    installMockImage({ shouldFail: true });
+    const engine = createLogoSoup();
+
+    engine.process({ logos: ["a.png", "b.png"] });
+
+    await waitFor(() => {
+      expect(engine.getSnapshot().status).toBe("error");
+    });
+
+    const snapshot = engine.getSnapshot();
+    expect(snapshot.failures).toHaveLength(2);
+    expect(snapshot.failures.map((f) => f.src)).toEqual(["a.png", "b.png"]);
+
+    engine.destroy();
+  });
+
   test("re-processing identical inputs keeps the snapshot referentially stable", async () => {
     installMockImage();
     const engine = createLogoSoup();


### PR DESCRIPTION
A logo that failed to load silently disappeared from the results with no way to tell which one broke. `state.error` was only set when every logo failed.

- Engine state now includes `failures: { src, error }[]`
- Exposed through every adapter: `useLogoSoup().failures`, plus Vue/Solid/Svelte getters
- React `<LogoSoup>` accepts an `onError(failures)` callback
- `status` and `error` semantics are unchanged

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
