### PR TITLE
feat: keep previous results while loading and fix the container fade-in

### DIFF
--- a/.changeset/keep-previous-data.md
+++ b/.changeset/keep-previous-data.md
@@ -1,0 +1,5 @@
+---
+"@sanity-labs/logo-soup": minor
+---
+
+Keep previous results visible while a new logo set loads instead of flashing to an empty state, and fix the React fade-in (the old per-item opacity transition never ran because items mounted already visible; the fade now lives on the always-mounted container). During `loading`, `normalizedLogos` now holds the previous run's results — use the `isLoading` flag or `data-logo-soup-loading` attribute to detect staleness.

--- a/src/core/create-logo-soup.ts
+++ b/src/core/create-logo-soup.ts
@@ -226,11 +226,12 @@ export function createLogoSoup(): LogoSoupEngine {
     };
 
     if (!allCached) {
+      // Keep previous results so consumers don't flash empty on set changes
       setState({
         status: "loading",
-        normalizedLogos: [],
+        normalizedLogos: snapshot.normalizedLogos,
         error: null,
-        failures: NO_FAILURES,
+        failures: snapshot.failures,
       });
     }
 

--- a/src/react/logo-soup.tsx
+++ b/src/react/logo-soup.tsx
@@ -7,7 +7,6 @@ import { useLogoSoup } from "./use-logo-soup";
 const logoWrapperStyle: CSSProperties = {
   display: "inline-block",
   verticalAlign: "middle",
-  transition: "opacity 0.2s ease-in-out",
 };
 
 const logoImageStyle: CSSProperties = {
@@ -64,9 +63,12 @@ export function LogoSoup({
 
   const halfGap = typeof gap === "number" ? `${gap / 2}px` : `calc(${gap} / 2)`;
 
+  // Fade on the always-mounted container; per-item opacity never transitioned
   const containerStyle: CSSProperties = {
     textAlign: "center",
     textWrap: "balance",
+    opacity: isLoading && normalizedLogos.length === 0 ? 0 : 1,
+    transition: "opacity 0.2s ease-in-out",
     ...style,
   };
 
@@ -91,7 +93,6 @@ export function LogoSoup({
             style={{
               ...logoWrapperStyle,
               padding: halfGap,
-              opacity: isLoading ? 0 : 1,
             }}
           >
             <ImageComponent

--- a/tests/createLogoSoup.test.ts
+++ b/tests/createLogoSoup.test.ts
@@ -307,6 +307,30 @@ describe("createLogoSoup", () => {
     engine.destroy();
   });
 
+  test("keeps previous results visible while a new logo set loads", async () => {
+    installMockImage();
+    const engine = createLogoSoup();
+
+    engine.process({ logos: ["a.png"] });
+    await waitFor(() => {
+      expect(engine.getSnapshot().status).toBe("ready");
+    });
+    const previous = engine.getSnapshot().normalizedLogos;
+
+    engine.process({ logos: ["b.png"] });
+
+    // Synchronously in loading, but previous logos are still there
+    expect(engine.getSnapshot().status).toBe("loading");
+    expect(engine.getSnapshot().normalizedLogos).toBe(previous);
+
+    await waitFor(() => {
+      expect(engine.getSnapshot().status).toBe("ready");
+    });
+    expect(engine.getSnapshot().normalizedLogos[0]?.src).toBe("b.png");
+
+    engine.destroy();
+  });
+
   test("partial failure: reports failures but stays ready with the successes", async () => {
     globalThis.Image = class MockImage {
       crossOrigin = "";


### PR DESCRIPTION
Changing the logo set flashed to an empty container, and the intended fade-in never ran: items mounted already visible, so the per-item opacity transition was dead code.

- The engine keeps the previous results (and failures) in state while a new set loads
- The fade moved to the always-mounted container, so first load actually fades in
- During `loading`, `normalizedLogos` now holds the previous run's results; use `isLoading` or `data-logo-soup-loading` to detect staleness

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
