### PR TITLE
feat: precomputed measurements for SSR and zero-CLS rendering

### DIFF
--- a/.changeset/precomputed-measurements.md
+++ b/.changeset/precomputed-measurements.md
@@ -1,0 +1,5 @@
+---
+"@sanity-labs/logo-soup": minor
+---
+
+Add a `measurements` option for pre-computed measurement data (e.g. from the Node adapter). The engine seeds its cache from it, skipping image loading and pixel scanning for covered logos. In React, full coverage renders the final layout on the very first pass — pure math, SSR-safe, zero layout shift. Partial coverage falls back to client-side measurement per logo.

--- a/docs/performance.mdx
+++ b/docs/performance.mdx
@@ -127,16 +127,25 @@ The library processes logos in parallel using `Promise.allSettled`, but each log
 
 ## Server-side pre-computation
 
-If you want to skip client-side pixel scanning entirely, the [Node.js adapter](/frameworks/node) lets you pre-compute `MeasurementResult` data at build time or in API routes using `@napi-rs/canvas`. The client then calls `createNormalizedLogo` with the pre-computed data -- pure math, no canvas, no async.
+If you want to skip client-side pixel scanning entirely, the [Node.js adapter](/frameworks/node) lets you pre-compute `MeasurementResult` data at build time or in API routes using `@napi-rs/canvas`. Pass the results to the `measurements` prop, keyed by the src the client will use:
 
 ```ts
 // Build script
 import { measureImages } from "@sanity-labs/logo-soup/node";
-const measurements = await measureImages(["./logos/acme.svg", "./logos/globex.svg"]);
 
-// Client
-import { createNormalizedLogo } from "@sanity-labs/logo-soup";
-const normalized = createNormalizedLogo(source, measurements[0], 48, 0.5, 0.5);
+const srcs = ["/logos/acme.svg", "/logos/globex.svg"];
+const results = await measureImages(srcs.map((s) => `./public${s}`));
+const measurements = Object.fromEntries(srcs.map((s, i) => [s, results[i]]));
+// Serialize to JSON and ship to the client
 ```
+
+```tsx
+// Client (or Server Component)
+import { LogoSoup } from "@sanity-labs/logo-soup/react";
+
+<LogoSoup logos={srcs} measurements={measurements} />;
+```
+
+When `measurements` covers every logo, normalization is pure math — no canvas, no image loading, no async. The component renders its final layout on the very first pass, which makes it SSR-safe and eliminates layout shift entirely. Logos without a pre-computed entry fall back to client-side measurement.
 
 See the [Node.js adapter docs](/frameworks/node) for the full workflow.

--- a/src/core/create-logo-soup.ts
+++ b/src/core/create-logo-soup.ts
@@ -12,7 +12,11 @@ import {
   measureWithContentDetection,
   resolveBackgroundColor,
 } from "./measure";
-import { createNormalizedLogo, normalizeSource } from "./normalize";
+import {
+  createNormalizedLogo,
+  normalizeSource,
+  resolveDensityFactor,
+} from "./normalize";
 import type {
   LogoFailure,
   LogoSoupEngine,
@@ -24,7 +28,7 @@ import type {
 } from "./types";
 
 interface CachedEntry {
-  img: HTMLImageElement;
+  img?: HTMLImageElement;
   measurement: MeasurementResult;
   blobUrl?: string;
 }
@@ -129,6 +133,7 @@ export function createLogoSoup(): LogoSoupEngine {
 
     const {
       logos,
+      measurements,
       baseSize = DEFAULT_BASE_SIZE,
       scaleFactor = DEFAULT_SCALE_FACTOR,
       contrastThreshold = DEFAULT_CONTRAST_THRESHOLD,
@@ -169,6 +174,15 @@ export function createLogoSoup(): LogoSoupEngine {
     const activeSrcs = new Set(sources.map((s) => s.src));
     pruneCache(activeSrcs);
 
+    if (measurements) {
+      for (const source of sources) {
+        const measurement = measurements[source.src];
+        if (measurement && !cache.has(source.src)) {
+          cache.set(source.src, { measurement });
+        }
+      }
+    }
+
     const allCached = sources.every((s) => cache.has(s.src));
     const needsCrop =
       cropToContent &&
@@ -177,7 +191,10 @@ export function createLogoSoup(): LogoSoupEngine {
         return entry && !entry.blobUrl && entry.measurement.contentBox;
       });
 
-    const effectiveDensityFactor = densityAware ? densityFactor : 0;
+    const effectiveDensityFactor = resolveDensityFactor(
+      densityAware,
+      densityFactor,
+    );
 
     const processKey = JSON.stringify([
       sources.map((s) => [s.src, s.alt ?? ""]),
@@ -262,6 +279,10 @@ export function createLogoSoup(): LogoSoupEngine {
         );
 
         if (cropToContent && entry.measurement.contentBox && !entry.blobUrl) {
+          if (!entry.img) {
+            entry.img = await loadImage(source.src);
+            if (cancelled) throw new Error("cancelled");
+          }
           const url = await cropToBlobUrl(
             entry.img,
             entry.measurement.contentBox,

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_BASE_SIZE,
+  DEFAULT_DENSITY_AWARE,
+  DEFAULT_DENSITY_FACTOR,
+  DEFAULT_SCALE_FACTOR,
+} from "./constants";
 import type {
   BackgroundColor,
   LogoSource,
@@ -30,6 +36,24 @@ export function backgroundColorsEqual(
   return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
 }
 
+export function measurementsEqual(
+  a: Record<string, MeasurementResult> | undefined,
+  b: Record<string, MeasurementResult> | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every((key) => a[key] === b[key]);
+}
+
+export function resolveDensityFactor(
+  densityAware: boolean = DEFAULT_DENSITY_AWARE,
+  densityFactor: number = DEFAULT_DENSITY_FACTOR,
+): number {
+  return densityAware ? densityFactor : 0;
+}
+
 export function normalizeSource(source: string | LogoSource): LogoSource {
   if (typeof source === "string") {
     return { src: source, alt: "" };
@@ -39,8 +63,8 @@ export function normalizeSource(source: string | LogoSource): LogoSource {
 
 export function calculateNormalizedDimensions(
   measurement: MeasurementResult,
-  baseSize: number,
-  scaleFactor: number,
+  baseSize: number = DEFAULT_BASE_SIZE,
+  scaleFactor: number = DEFAULT_SCALE_FACTOR,
   densityFactor: number = 0,
 ): { width: number; height: number } {
   const contentWidth = measurement.contentBox
@@ -115,8 +139,8 @@ export function calculateNormalizedDimensions(
 export function createNormalizedLogo(
   source: LogoSource,
   measurement: MeasurementResult,
-  baseSize: number,
-  scaleFactor: number,
+  baseSize: number = DEFAULT_BASE_SIZE,
+  scaleFactor: number = DEFAULT_SCALE_FACTOR,
   densityFactor: number = 0,
 ): NormalizedLogo {
   const { width, height } = calculateNormalizedDimensions(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -56,6 +56,8 @@ export type MeasurementResult = {
 /** Options passed to `engine.process()` */
 export type ProcessOptions = {
   logos: (string | LogoSource)[];
+  /** Pre-computed measurements keyed by src (e.g. from the Node adapter); seeds the cache and skips load + pixel scan */
+  measurements?: Record<string, MeasurementResult>;
   baseSize?: number;
   scaleFactor?: number;
   contrastThreshold?: number;

--- a/src/react/logo-soup.tsx
+++ b/src/react/logo-soup.tsx
@@ -21,6 +21,7 @@ function DefaultImage(props: ImageRenderProps) {
 
 export function LogoSoup({
   logos,
+  measurements,
   baseSize,
   scaleFactor,
   contrastThreshold,
@@ -38,6 +39,7 @@ export function LogoSoup({
 }: LogoSoupProps) {
   const { isLoading, isReady, normalizedLogos, error, failures } = useLogoSoup({
     logos,
+    measurements,
     baseSize,
     scaleFactor,
     contrastThreshold,

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -4,6 +4,7 @@ import type {
   BackgroundColor,
   LogoFailure,
   LogoSource,
+  MeasurementResult,
   NormalizedLogo,
 } from "../core/types";
 
@@ -19,6 +20,8 @@ export type RenderImageFn = (props: ImageRenderProps) => ReactNode;
 
 export type UseLogoSoupOptions = {
   logos: (string | LogoSource)[];
+  /** Pre-computed measurements keyed by src (e.g. from the Node adapter). Full coverage renders synchronously — SSR-safe, zero CLS */
+  measurements?: Record<string, MeasurementResult>;
   baseSize?: number;
   scaleFactor?: number;
   contrastThreshold?: number;
@@ -39,6 +42,8 @@ export type UseLogoSoupResult = {
 
 export type LogoSoupProps = {
   logos: (string | LogoSource)[];
+  /** Pre-computed measurements keyed by src (e.g. from the Node adapter). Full coverage renders synchronously — SSR-safe, zero CLS */
+  measurements?: Record<string, MeasurementResult>;
   baseSize?: number;
   scaleFactor?: number;
   contrastThreshold?: number;

--- a/src/react/use-logo-soup.ts
+++ b/src/react/use-logo-soup.ts
@@ -1,7 +1,20 @@
-import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import { createLogoSoup } from "../core/create-logo-soup";
-import { backgroundColorsEqual, logosEqual } from "../core/normalize";
-import type { LogoSoupState } from "../core/types";
+import {
+  backgroundColorsEqual,
+  createNormalizedLogo,
+  logosEqual,
+  measurementsEqual,
+  normalizeSource,
+  resolveDensityFactor,
+} from "../core/normalize";
+import type { LogoSoupState, NormalizedLogo } from "../core/types";
 import type { UseLogoSoupOptions, UseLogoSoupResult } from "./types";
 
 const SERVER_SNAPSHOT: LogoSoupState = {
@@ -41,13 +54,18 @@ export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupResult {
   );
   const getSnapshot = useCallback(() => engine.getSnapshot(), [engine]);
 
-  const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const storeState = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
 
   const stableLogos = useStableValue(options.logos, logosEqual);
   const backgroundColor = useStableValue(
     options.backgroundColor,
     backgroundColorsEqual,
   );
+  const measurements = useStableValue(options.measurements, measurementsEqual);
 
   const {
     baseSize,
@@ -57,6 +75,47 @@ export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupResult {
     densityFactor,
     cropToContent,
   } = options;
+
+  // When measurements cover every logo, the ready state is pure math — no
+  // canvas, no network. Computed in render so SSR emits final HTML (zero CLS)
+  const precomputedState = useMemo((): LogoSoupState | null => {
+    if (!measurements || cropToContent) return null;
+    const effectiveDensityFactor = resolveDensityFactor(
+      densityAware,
+      densityFactor,
+    );
+    const results: NormalizedLogo[] = [];
+    for (const logo of stableLogos) {
+      const source = normalizeSource(logo);
+      const measurement = measurements[source.src];
+      if (!measurement) return null;
+      results.push(
+        createNormalizedLogo(
+          source,
+          measurement,
+          baseSize,
+          scaleFactor,
+          effectiveDensityFactor,
+        ),
+      );
+    }
+    return {
+      status: "ready",
+      normalizedLogos: results,
+      error: null,
+      failures: [],
+    };
+  }, [
+    stableLogos,
+    measurements,
+    baseSize,
+    scaleFactor,
+    densityAware,
+    densityFactor,
+    cropToContent,
+  ]);
+
+  const state = precomputedState ?? storeState;
 
   // Holds a deferred destroy timer so that StrictMode remounts can cancel it
   // before it fires. On a real unmount no remount follows and the timer
@@ -72,6 +131,7 @@ export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupResult {
 
     engine.process({
       logos: stableLogos,
+      measurements,
       baseSize,
       scaleFactor,
       contrastThreshold,
@@ -88,6 +148,7 @@ export function useLogoSoup(options: UseLogoSoupOptions): UseLogoSoupResult {
   }, [
     engine,
     stableLogos,
+    measurements,
     baseSize,
     scaleFactor,
     contrastThreshold,

--- a/tests/createLogoSoup.test.ts
+++ b/tests/createLogoSoup.test.ts
@@ -307,6 +307,29 @@ describe("createLogoSoup", () => {
     engine.destroy();
   });
 
+  test("seeded measurements produce a synchronous ready state with no image loads", () => {
+    globalThis.Image = class MockImage {
+      constructor() {
+        throw new Error("Image should not be constructed when seeded");
+      }
+    } as unknown as typeof Image;
+
+    const engine = createLogoSoup();
+    engine.process({
+      logos: ["a.png"],
+      measurements: {
+        "a.png": { width: 200, height: 100 },
+      },
+    });
+
+    const snapshot = engine.getSnapshot();
+    expect(snapshot.status).toBe("ready");
+    expect(snapshot.normalizedLogos).toHaveLength(1);
+    expect(snapshot.normalizedLogos[0]?.originalWidth).toBe(200);
+
+    engine.destroy();
+  });
+
   test("keeps previous results visible while a new logo set loads", async () => {
     installMockImage();
     const engine = createLogoSoup();

--- a/tests/useLogoSoup.test.tsx
+++ b/tests/useLogoSoup.test.tsx
@@ -268,6 +268,56 @@ describe("useLogoSoup", () => {
     globalThis.Image = originalImage;
   });
 
+  test("full measurements coverage is ready on the very first render", () => {
+    globalThis.Image = class MockImage {
+      constructor() {
+        throw new Error("Image should not be constructed when precomputed");
+      }
+    } as unknown as typeof Image;
+
+    const { result } = renderHook(() =>
+      useLogoSoup({
+        logos: ["https://example.com/logo.png"],
+        measurements: {
+          "https://example.com/logo.png": { width: 200, height: 100 },
+        },
+        densityAware: false,
+      }),
+    );
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.normalizedLogos).toHaveLength(1);
+    expect(result.current.normalizedLogos[0]?.normalizedWidth).toBeGreaterThan(
+      0,
+    );
+
+    globalThis.Image = originalImage;
+  });
+
+  test("inline measurements object keeps results referentially stable", () => {
+    globalThis.Image = class MockImage {
+      constructor() {
+        throw new Error("Image should not be constructed when precomputed");
+      }
+    } as unknown as typeof Image;
+
+    const measurement = { width: 200, height: 100 };
+    const { result, rerender } = renderHook(() =>
+      useLogoSoup({
+        logos: ["https://example.com/logo.png"],
+        // New wrapper object every render — must not produce new results
+        measurements: { "https://example.com/logo.png": measurement },
+      }),
+    );
+
+    const first = result.current.normalizedLogos;
+    rerender();
+
+    expect(result.current.normalizedLogos).toBe(first);
+
+    globalThis.Image = originalImage;
+  });
+
   test("works correctly under React StrictMode (not stuck in loading)", async () => {
     globalThis.Image = class MockImage {
       crossOrigin = "";


### PR DESCRIPTION
Adds a `measurements` option for pre-computed measurement data from the Node adapter. The engine seeds its cache from it, skipping image loading and pixel scanning. In React, full coverage renders the final layout on the very first pass: pure math, SSR safe, zero layout shift.

```ts
// Build time
import { measureImages } from "@sanity-labs/logo-soup/node";
const results = await measureImages(srcs.map((s) => `./public${s}`));
const measurements = Object.fromEntries(srcs.map((s, i) => [s, results[i]]));
```

```tsx
// Client or Server Component
<LogoSoup logos={srcs} measurements={measurements} />
```

- Partial coverage falls back to client-side measurement per logo
- `cropToContent` still requires the async path (needs decoded pixels)
- Shared default resolution extracted (`resolveDensityFactor`, defaults on `createNormalizedLogo`) so the hook and engine can't drift
- Docs updated in `docs/performance.mdx`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
