### PR TITLE
chore: add Biome lint/format and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run build
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bunx biome ci .
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.storybook/manager.tsx
+++ b/.storybook/manager.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { addons, types } from "storybook/manager-api";
 import { BookIcon } from "@storybook/icons";
+// biome-ignore lint/correctness/noUnusedImports: Storybook's manager builder compiles JSX with the classic runtime, so React must be in scope
+import React from "react";
 import { Button } from "storybook/internal/components";
+import { addons, types } from "storybook/manager-api";
 
 const DOCS_URL = "https://logo-soup.sanity.dev/docs/introduction";
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
+  "files": {
+    "includes": [
+      "src/**",
+      "tests/**",
+      "stories/**",
+      "scripts/**",
+      ".storybook/**",
+      "!tests/golden-measurements.json"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "style": {
+        "noNonNullAssertion": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "react-logo-soup",
       "devDependencies": {
         "@angular/core": "^19",
+        "@biomejs/biome": "^2.5.9",
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
         "@chromatic-com/storybook": "^5.0.1",
@@ -33,6 +34,8 @@
       },
       "peerDependencies": {
         "@angular/core": "^19 || ^20 || ^21",
+        "@napi-rs/canvas": "^0.1.90",
+        "jquery": "^4",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "solid-js": "^1.9",
@@ -42,6 +45,8 @@
       },
       "optionalPeers": [
         "@angular/core",
+        "@napi-rs/canvas",
+        "jquery",
         "react",
         "react-dom",
         "solid-js",
@@ -113,6 +118,24 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.9", "@biomejs/cli-darwin-x64": "2.5.9", "@biomejs/cli-linux-arm64": "2.5.9", "@biomejs/cli-linux-arm64-musl": "2.5.9", "@biomejs/cli-linux-x64": "2.5.9", "@biomejs/cli-linux-x64-musl": "2.5.9", "@biomejs/cli-win32-arm64": "2.5.9", "@biomejs/cli-win32-x64": "2.5.9" }, "bin": { "biome": "bin/biome" } }, "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.9", "", { "os": "linux", "cpu": "x64" }, "sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.9", "", { "os": "linux", "cpu": "x64" }, "sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.9", "", { "os": "win32", "cpu": "x64" }, "sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.0", "", { "dependencies": { "@changesets/config": "^3.1.3", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ=="],
 

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
     "generate:logos": "bun scripts/generate-test-logos.ts",
     "prepublishOnly": "bun run build",
     "test": "NODE_ENV=development bun test",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
     "bench": "bun tests/bench/run.ts",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
@@ -125,6 +127,7 @@
   "license": "MIT",
   "devDependencies": {
     "@angular/core": "^19",
+    "@biomejs/biome": "^2.5.9",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
     "@chromatic-com/storybook": "^5.0.1",

--- a/src/angular/logo-soup.service.ts
+++ b/src/angular/logo-soup.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, signal, inject, DestroyRef } from "@angular/core";
+import { DestroyRef, Injectable, inject, signal } from "@angular/core";
 import { createLogoSoup as createEngine } from "../core/create-logo-soup";
-import type { ProcessOptions, LogoSoupState } from "../core/types";
+import type { LogoSoupState, ProcessOptions } from "../core/types";
 
 const IDLE_STATE: LogoSoupState = {
   status: "idle",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,10 +1,3 @@
-export { createLogoSoup } from "./create-logo-soup";
-export { getVisualCenterTransform } from "./get-visual-center-transform";
-export { cropToDataUrl } from "./measure";
-export {
-  calculateNormalizedDimensions,
-  createNormalizedLogo,
-} from "./normalize";
 export {
   DEFAULT_ALIGN_BY,
   DEFAULT_BASE_SIZE,
@@ -15,6 +8,13 @@ export {
   DEFAULT_GAP,
   DEFAULT_SCALE_FACTOR,
 } from "./constants";
+export { createLogoSoup } from "./create-logo-soup";
+export { getVisualCenterTransform } from "./get-visual-center-transform";
+export { cropToDataUrl } from "./measure";
+export {
+  calculateNormalizedDimensions,
+  createNormalizedLogo,
+} from "./normalize";
 export type {
   AlignmentMode,
   BackgroundColor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,5 @@
 // Core — framework-agnostic
-export { createLogoSoup } from "./core/create-logo-soup";
-export { getVisualCenterTransform } from "./core/get-visual-center-transform";
-export { cropToDataUrl } from "./core/measure";
-export {
-  calculateNormalizedDimensions,
-  createNormalizedLogo,
-} from "./core/normalize";
+
 export {
   DEFAULT_ALIGN_BY,
   DEFAULT_BASE_SIZE,
@@ -16,6 +10,13 @@ export {
   DEFAULT_GAP,
   DEFAULT_SCALE_FACTOR,
 } from "./core/constants";
+export { createLogoSoup } from "./core/create-logo-soup";
+export { getVisualCenterTransform } from "./core/get-visual-center-transform";
+export { cropToDataUrl } from "./core/measure";
+export {
+  calculateNormalizedDimensions,
+  createNormalizedLogo,
+} from "./core/normalize";
 export type {
   AlignmentMode,
   BackgroundColor,
@@ -31,7 +32,6 @@ export type {
 
 // React adapter
 export { LogoSoup } from "./react/logo-soup";
-export { useLogoSoup } from "./react/use-logo-soup";
 export type {
   ImageRenderProps,
   LogoSoupProps,
@@ -39,3 +39,4 @@ export type {
   UseLogoSoupOptions,
   UseLogoSoupResult,
 } from "./react/types";
+export { useLogoSoup } from "./react/use-logo-soup";

--- a/src/jquery/index.ts
+++ b/src/jquery/index.ts
@@ -1,7 +1,7 @@
 import { install } from "./plugin";
 
-export { install };
 export type { LogoSoupPluginOptions } from "./plugin";
+export { install };
 
 // Auto-install if jQuery is available globally
 if (typeof window !== "undefined" && (window as any).jQuery) {

--- a/src/jquery/plugin.ts
+++ b/src/jquery/plugin.ts
@@ -1,9 +1,8 @@
+import { DEFAULT_ALIGN_BY, DEFAULT_GAP } from "../core/constants";
 import { createLogoSoup as createEngine } from "../core/create-logo-soup";
 import { getVisualCenterTransform } from "../core/get-visual-center-transform";
-import { DEFAULT_ALIGN_BY, DEFAULT_GAP } from "../core/constants";
 import type {
   AlignmentMode,
-  LogoSource,
   NormalizedLogo,
   ProcessOptions,
 } from "../core/types";

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,8 +1,13 @@
-import { createCanvas, loadImage as loadNativeImage } from "@napi-rs/canvas";
 import { readFile } from "node:fs/promises";
+import { createCanvas, loadImage as loadNativeImage } from "@napi-rs/canvas";
 import { measureContent } from "../core/measure-pixels";
 import type { MeasurementResult } from "../core/types";
 
+export { getVisualCenterTransform } from "../core/get-visual-center-transform";
+export {
+  calculateNormalizedDimensions,
+  createNormalizedLogo,
+} from "../core/normalize";
 export type {
   AlignmentMode,
   BoundingBox,
@@ -11,11 +16,6 @@ export type {
   NormalizedLogo,
   VisualCenter,
 } from "../core/types";
-export {
-  calculateNormalizedDimensions,
-  createNormalizedLogo,
-} from "../core/normalize";
-export { getVisualCenterTransform } from "../core/get-visual-center-transform";
 
 export type MeasureOptions = {
   contrastThreshold?: number;

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,5 +1,4 @@
 export { LogoSoup } from "./logo-soup";
-export { useLogoSoup } from "./use-logo-soup";
 export type {
   ImageRenderProps,
   LogoSoupProps,
@@ -7,3 +6,4 @@ export type {
   UseLogoSoupOptions,
   UseLogoSoupResult,
 } from "./types";
+export { useLogoSoup } from "./use-logo-soup";

--- a/src/react/logo-soup.tsx
+++ b/src/react/logo-soup.tsx
@@ -16,6 +16,7 @@ const logoImageStyle: CSSProperties = {
 
 function DefaultImage(props: ImageRenderProps) {
   // crossOrigin must match loadImage's, or browsers re-download every logo
+  // biome-ignore lint/a11y/useAltText: alt is required in ImageRenderProps
   return <img crossOrigin="anonymous" decoding="async" {...props} />;
 }
 
@@ -79,6 +80,7 @@ export function LogoSoup({
   }
 
   return (
+    // biome-ignore lint/a11y/useSemanticElements: ul/li would inherit list styling consumers must reset
     <div
       className={className}
       style={containerStyle}
@@ -89,7 +91,9 @@ export function LogoSoup({
         const transform = getVisualCenterTransform(logo, alignBy);
 
         return (
+          // biome-ignore lint/a11y/useSemanticElements: see role="list" above
           <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: src alone can repeat; index disambiguates duplicates
             key={`${logo.src}-${index}`}
             role="listitem"
             style={{

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -1,2 +1,2 @@
-export { useLogoSoup } from "./use-logo-soup";
 export type { UseLogoSoupResult } from "./use-logo-soup";
+export { useLogoSoup } from "./use-logo-soup";

--- a/src/solid/use-logo-soup.ts
+++ b/src/solid/use-logo-soup.ts
@@ -1,4 +1,4 @@
-import { from, createEffect, onCleanup } from "solid-js";
+import { createEffect, from, onCleanup } from "solid-js";
 import { createLogoSoup as createEngine } from "../core/create-logo-soup";
 import type {
   LogoFailure,

--- a/src/svelte/create-logo-soup.svelte.ts
+++ b/src/svelte/create-logo-soup.svelte.ts
@@ -1,6 +1,6 @@
 import { createSubscriber } from "svelte/reactivity";
 import { createLogoSoup as createEngine } from "../core/create-logo-soup";
-import type { ProcessOptions, LogoSoupState } from "../core/types";
+import type { LogoSoupState, ProcessOptions } from "../core/types";
 
 export function createLogoSoup() {
   const engine = createEngine();

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,2 +1,2 @@
-export { useLogoSoup } from "./use-logo-soup";
 export type { UseLogoSoupOptions, UseLogoSoupReturn } from "./use-logo-soup";
+export { useLogoSoup } from "./use-logo-soup";

--- a/src/vue/use-logo-soup.ts
+++ b/src/vue/use-logo-soup.ts
@@ -1,19 +1,19 @@
 import {
-  shallowRef,
-  watchEffect,
-  onScopeDispose,
-  toValue,
+  type ComputedRef,
   computed,
   type MaybeRefOrGetter,
+  onScopeDispose,
   type ShallowRef,
-  type ComputedRef,
+  shallowRef,
+  toValue,
+  watchEffect,
 } from "vue";
 import { createLogoSoup } from "../core/create-logo-soup";
 import type {
   BackgroundColor,
   LogoFailure,
-  LogoSource,
   LogoSoupState,
+  LogoSource,
   NormalizedLogo,
 } from "../core/types";
 

--- a/stories/LogoSoup.DarkMode.stories.tsx
+++ b/stories/LogoSoup.DarkMode.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useMemo } from "react";
 import {
-  type StoryArgs,
-  StoryLogoSoup,
   allLogos,
   allLogosInverted,
   allLogosJpg,
   countArgType,
   defaultStoryArgs,
+  type StoryArgs,
+  StoryLogoSoup,
   shuffleArray,
   storyArgTypes,
 } from "./shared";

--- a/stories/LogoSoup.stories.tsx
+++ b/stories/LogoSoup.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useMemo } from "react";
 import {
-  type StoryArgs,
-  StoryLogoSoup,
   allLogos,
   countArgType,
   defaultStoryArgs,
+  type StoryArgs,
+  StoryLogoSoup,
   shuffleArray,
   storyArgTypes,
 } from "./shared";

--- a/stories/shared.tsx
+++ b/stories/shared.tsx
@@ -1,6 +1,4 @@
 import type { CSSProperties, ImgHTMLAttributes } from "react";
-import { LogoSoup } from "../src/react/logo-soup";
-import type { LogoSoupProps } from "../src/react/types";
 import {
   DEFAULT_ALIGN_BY,
   DEFAULT_BASE_SIZE,
@@ -9,6 +7,8 @@ import {
   DEFAULT_GAP,
   DEFAULT_SCALE_FACTOR,
 } from "../src/core/constants";
+import { LogoSoup } from "../src/react/logo-soup";
+import type { LogoSoupProps } from "../src/react/types";
 
 const logoNames = [
   "aether",

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -12,7 +12,6 @@ import {
   DEFAULT_DENSITY_FACTOR,
   DEFAULT_SCALE_FACTOR,
 } from "../../src/core/constants";
-import type { LogoSource, MeasurementResult } from "../../src/core/types";
 import { getVisualCenterTransform } from "../../src/core/get-visual-center-transform";
 import {
   cropToDataUrl,
@@ -20,6 +19,7 @@ import {
   measureWithContentDetection,
 } from "../../src/core/measure";
 import { createNormalizedLogo } from "../../src/core/normalize";
+import type { LogoSource, MeasurementResult } from "../../src/core/types";
 import { fmtCost, fmtNs, fmtP, welchTTest } from "./welch";
 
 const origCreateElement = document.createElement.bind(document);

--- a/tests/createLogoSoup.test.ts
+++ b/tests/createLogoSoup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, afterEach } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { createLogoSoup } from "../src/core/create-logo-soup";
 
 const originalImage = globalThis.Image;

--- a/tests/node.test.ts
+++ b/tests/node.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { join } from "node:path";
 import { readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { createCanvas, loadImage as loadNativeImage } from "@napi-rs/canvas";
-import { measureImage, measureImages } from "../src/node/index";
 import { downsampleDimensions, scanPixels } from "../src/core/measure-pixels";
+import { measureImage, measureImages } from "../src/node/index";
 
 const LOGOS_DIR = join(import.meta.dir, "../static/logos");
 

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { LogoSource, MeasurementResult } from "../src/core/types";
 import {
   calculateNormalizedDimensions,
   createNormalizedLogo,
   normalizeSource,
 } from "../src/core/normalize";
+import type { LogoSource, MeasurementResult } from "../src/core/types";
 
 describe("normalizeSource", () => {
   test("converts string to LogoSource", () => {

--- a/tests/useLogoSoup.test.tsx
+++ b/tests/useLogoSoup.test.tsx
@@ -1,6 +1,6 @@
-import { describe, test, expect } from "bun:test";
-import { StrictMode, type ReactNode } from "react";
+import { describe, expect, test } from "bun:test";
 import { renderHook, waitFor } from "@testing-library/react";
+import { type ReactNode, StrictMode } from "react";
 import { useLogoSoup } from "../src/react/use-logo-soup";
 
 const originalImage = globalThis.Image;


### PR DESCRIPTION
Adds Biome for linting and formatting with a CI job. The repo had no lint step.

- `biome.json` matching the existing style; `noNonNullAssertion` off (deliberate pattern in hot pixel loops)
- `bun run lint` / `bun run lint:fix` scripts and a `lint` CI job
- Applies safe fixes: import sorting and a pre-existing unused import in the jQuery adapter
- Targeted inline suppressions with reasons in `logo-soup.tsx` and `.storybook/manager.tsx`

Note: `import React` in `.storybook/manager.tsx` looks unused but is load-bearing. Storybook's manager builder compiles JSX with the classic runtime, so removing it breaks the manager UI at runtime with "React is not defined" (the build still passes). It's kept with a suppression explaining why.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
